### PR TITLE
Add gem initializer when running the install task

### DIFF
--- a/lib/install/config/initializers/webauthn_rails.rb
+++ b/lib/install/config/initializers/webauthn_rails.rb
@@ -1,0 +1,5 @@
+Webauthn::Rails.configure do |config|
+  # This value needs to match `window.location.origin` evaluated by
+  # the User Agent during registration and authentication ceremonies.
+  # config.webauthn_origin = "https://auth.example.com"
+end

--- a/lib/install/with_importmap.rb
+++ b/lib/install/with_importmap.rb
@@ -12,3 +12,5 @@ append_to_file "config/importmap.rb", %(pin "@github/webauthn-json", to: "https:
 
 say %(Appending: pin "webauthn-rails/credential", to: "credential.js")
 append_to_file "config/importmap.rb", %(pin "webauthn-rails/credential", to: "credential.js"\n)
+
+copy_file "#{__dir__}/config/initializers/webauthn_rails.rb", "config/initializers/webauthn_rails.rb"


### PR DESCRIPTION
As part of the `webauthn_rails:install` task, let's create an initializer in the main app so that users can easily change the `webauthn_origin` value.