### PR TITLE
Add user model if not exists when installing the gem

### DIFF
--- a/lib/generators/webauthn/rails/install_generator.rb
+++ b/lib/generators/webauthn/rails/install_generator.rb
@@ -53,10 +53,12 @@ module Webauthn
           end
 
           migration_template "db/migrate/add_webauthn_to_users.rb", "db/migrate/add_webauthn_to_users.rb"
-          migration_template "db/migrate/create_webauthn_rails_credentials.rb", "db/migrate/create_webauthn_rails_credentials.rb"
         else
-          say "Tried to inject webauthn into user model but couldn't find it"
+          template "app/models/user.rb"
+          migration_template "db/migrate/create_users.rb", "db/migrate/create_users.rb"
         end
+
+        migration_template "db/migrate/create_webauthn_rails_credentials.rb", "db/migrate/create_webauthn_rails_credentials.rb"
       end
     end
   end

--- a/lib/generators/webauthn/rails/templates/app/models/user.rb
+++ b/lib/generators/webauthn/rails/templates/app/models/user.rb
@@ -1,0 +1,9 @@
+class User < ApplicationRecord
+  validates :username, presence: true, uniqueness: true
+
+  has_many :credentials, dependent: :destroy, class_name: 'Webauthn::Rails::Credential'
+
+  after_initialize do
+    self.webauthn_id ||= WebAuthn.generate_user_id
+  end
+end

--- a/lib/generators/webauthn/rails/templates/db/migrate/create_users.rb
+++ b/lib/generators/webauthn/rails/templates/db/migrate/create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :users do |t|
+      t.string :username
+      t.string :webauthn_id
+
+      t.timestamps
+    end
+    add_index :users, :username, unique: true
+  end
+end


### PR DESCRIPTION
## Motivation

The idea is to automatically add the User model if it not exists, with the necessary validations, associations and migrations, so that we reduce the overhead of adding the user model and set it up correctly to work with webauthn.