### PR TITLE
Use a different artifact name for each `Ruby` version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,6 @@ jobs:
       uses: actions/upload-artifact@v4
       if: failure()
       with:
-        name: screenshots
+        name: screenshots-${{ matrix.ruby }}
         path: ${{ github.workspace }}/test/dummy/tmp/screenshots
         if-no-files-found: ignore


### PR DESCRIPTION
#### Why

Currently, when two or more tests fail at the same time, the upload artifact job fails with the following error:

<img width="1320" alt="image" src="https://github.com/user-attachments/assets/5eec95ea-704f-42f6-ab2e-dfb37a8ec91b" />
