### PR TITLE
Fix WebAuthn deprecation warning

### DIFF
--- a/lib/generators/webauthn/rails/templates/config/initializers/webauthn.rb
+++ b/lib/generators/webauthn/rails/templates/config/initializers/webauthn.rb
@@ -1,7 +1,7 @@
 WebAuthn.configure do |config|
   # This value needs to match `window.location.origin` evaluated by
   # the User Agent during registration and authentication ceremonies.
-  # config.origin = "https://auth.example.com"
+  # config.allowed_origins = [ "https://auth.example.com" ]
 
   # Relying Party name for display purposes
   # config.rp_name = "Example Inc."

--- a/test/dummy/config/initializers/webauthn.rb
+++ b/test/dummy/config/initializers/webauthn.rb
@@ -1,7 +1,7 @@
 WebAuthn.configure do |config|
   # This value needs to match `window.location.origin` evaluated by
   # the User Agent during registration and authentication ceremonies.
-  config.origin = "http://localhost:3030"
+  config.allowed_origins = [ "http://localhost:3030" ]
 
   # Relying Party name for display purposes
   config.rp_name = "WebAuthn Rails Demo App"


### PR DESCRIPTION
### Summary:
- Change `origin` to `allowed origins` in configuration. 