### PR TITLE
Store `id` instead of encoded `raw_id` on `external_id` column

### DIFF
--- a/app/controllers/webauthn/rails/credentials_controller.rb
+++ b/app/controllers/webauthn/rails/credentials_controller.rb
@@ -30,7 +30,7 @@ module Webauthn
           )
 
           credential = current_user.webauthn_credentials.find_or_initialize_by(
-            external_id: Base64.strict_encode64(webauthn_credential.raw_id)
+            external_id: webauthn_credential.id
           )
 
           if credential.update(

--- a/app/controllers/webauthn/rails/registrations_controller.rb
+++ b/app/controllers/webauthn/rails/registrations_controller.rb
@@ -44,7 +44,7 @@ module Webauthn
           )
 
           user.webauthn_credentials.build(
-            external_id: Base64.strict_encode64(webauthn_credential.raw_id),
+            external_id: webauthn_credential.id,
             nickname: params[:credential_nickname],
             public_key: webauthn_credential.public_key,
             sign_count: webauthn_credential.sign_count

--- a/app/controllers/webauthn/rails/sessions_controller.rb
+++ b/app/controllers/webauthn/rails/sessions_controller.rb
@@ -35,7 +35,7 @@ module Webauthn
         user = User.find_by(username: session[:current_authentication][:username] || session[:current_authentication]["username"])
         raise "user #{session[:current_authentication][:username]} never initiated sign up" unless user
 
-        stored_credential = user.webauthn_credentials.find_by(external_id: Base64.strict_encode64(webauthn_credential.raw_id))
+        stored_credential = user.webauthn_credentials.find_by(external_id: webauthn_credential.id)
 
         begin
           webauthn_credential.verify(

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -45,7 +45,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
       username: "bob",
       webauthn_credentials: [
         WebauthnCredential.new(
-          external_id: Base64.strict_encode64(webauthn_credential.raw_id),
+          external_id: webauthn_credential.id,
           nickname: "Bob's USB Key",
           public_key: webauthn_credential.public_key,
           sign_count: webauthn_credential.sign_count


### PR DESCRIPTION
This will make it easier to stop using `webauthn-json`.

With `webauthn-json` the `create()` method expects `createOptions` of type `JSON`. However, for using the browser's native API, the `create()` call must receive the options in type `CredentialCreationOptions`.

To pass from `JSON` to `CredentialCreationOptions` the method `parseRequestOptionsFromJSON` is used.
`parseRequestOptionsFromJSON` in turn, expects to receive this format: https://www.w3.org/TR/webauthn-3/#dictdef-publickeycredentialcreationoptionsjson

Therefore, the credential ids inside `excludeCredentials` need to be of type `Base64URLString`, which **is not the case now**.
As of now, the `raw_id` is being `strict encoded` which still doesn't comply with being of type `Base64URLString`.

With this PR, instead of strictly encoding the `raw_id`, the `id` attribute starts being stored.
The [id](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/id)  is a base64url encoded version of [PublicKeyCredential.rawId](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/rawId).


### Related discussion: 
- https://github.com/cedarcode/webauthn-rails/pull/31#discussion_r2257610446
