### PR TITLE
Bump `sqlite3` from `1.4` to `2.7`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "rails", "~> 7.2"
 
 gem "puma"
 
-gem "sqlite3", "~> 1.4"
+gem "sqlite3", "~> 2.7"
 
 gem "sprockets-rails"
 


### PR DESCRIPTION
Required to upgrade rails to 8.0:
https://github.com/rails/rails/blob/2c3ea36fe98e36039636655d23ae210ee2670dff/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L14