### PR TITLE
Remove unnecessary directory creation call in generator

### DIFF
--- a/lib/generators/webauthn/rails/install_generator.rb
+++ b/lib/generators/webauthn/rails/install_generator.rb
@@ -13,7 +13,6 @@ module Webauthn
       def copy_stimulus_controllers
         if using_importmap? || using_bun? || has_package_json?
           say "Add Webauthn Stimulus controllers"
-          empty_directory "app/javascript/controllers"
           template "app/javascript/controllers/webauthn_credentials_controller.js"
 
           if using_bun? || has_package_json?


### PR DESCRIPTION
`empty_directory` creates an empty directory, unless a directory exists already ([ref](https://github.com/rails/thor/blob/main/lib/thor/actions/empty_directory.rb)).
It's safe to assume that `app/javascript/controllers` exists already, as it gets created with `rails new`.

Furthermore, if the directory didn't exist, the `template` call creates it, together with the new file.