### PR TITLE
Rename Session Controller

### DIFF
--- a/lib/generators/erb/webauthn_authentication/templates/app/views/webauthn_sessions/new.html.erb.tt
+++ b/lib/generators/erb/webauthn_authentication/templates/app/views/webauthn_sessions/new.html.erb.tt
@@ -2,12 +2,12 @@
 
 <%%= form_with(
   scope: :session,
-  url: session_path,
+  url: webauthn_session_path,
   id: "new-session",
   data: {
     controller: "webauthn-credentials",
     action: "webauthn-credentials#get:prevent",
-    "webauthn-credentials-options-url-value": get_options_session_path,
+    "webauthn-credentials-options-url-value": get_options_webauthn_session_path,
   }) do |form| %>
 
   <div class="field">

--- a/lib/generators/erb/webauthn_authentication/webauthn_authentication_generator.rb
+++ b/lib/generators/erb/webauthn_authentication/webauthn_authentication_generator.rb
@@ -9,7 +9,7 @@ module Erb
       def create_files
         template "app/views/webauthn_credentials/new.html.erb.tt"
         template "app/views/registrations/new.html.erb.tt"
-        template "app/views/sessions/new.html.erb.tt"
+        template "app/views/webauthn_sessions/new.html.erb.tt"
       end
     end
   end

--- a/lib/generators/test_unit/webauthn_authentication/templates/test/controllers/webauthn_sessions_controller_test.rb
+++ b/lib/generators/test_unit/webauthn_authentication/templates/test/controllers/webauthn_sessions_controller_test.rb
@@ -1,23 +1,23 @@
 require "test_helper"
 
-class SessionsControllerTest < ActionDispatch::IntegrationTest
+class WebauthnSessionsControllerTest < ActionDispatch::IntegrationTest
   test "should initiate registration successfully" do
     User.create!(username: "alice")
 
-    post get_options_session_url, params: { session: { username: "alice" } }
+    post get_options_webauthn_session_url, params: { session: { username: "alice" } }
 
     assert_response :success
   end
 
   test "should return error if creating session with inexisting username" do
-    post get_options_session_url, params: { session: { username: "alice" } }
+    post get_options_webauthn_session_url, params: { session: { username: "alice" } }
 
     assert_response :unprocessable_entity
     assert_equal [ "Username doesn't exist" ], JSON.parse(response.body)["errors"]
   end
 
   test "should return error if creating session with blank username" do
-    post get_options_session_url, params: { session: { username: "" } }
+    post get_options_webauthn_session_url, params: { session: { username: "" } }
 
     assert_response :unprocessable_entity
     assert_equal [ "Username doesn't exist" ], JSON.parse(response.body)["errors"]

--- a/lib/generators/test_unit/webauthn_authentication/webauthn_authentication_generator.rb
+++ b/lib/generators/test_unit/webauthn_authentication/webauthn_authentication_generator.rb
@@ -8,7 +8,7 @@ module TestUnit
 
       def create_controller_test_files
         template "test/controllers/registrations_controller_test.rb"
-        template "test/controllers/sessions_controller_test.rb"
+        template "test/controllers/webauthn_sessions_controller_test.rb"
       end
 
       def create_system_test_files

--- a/lib/generators/webauthn_authentication/templates/app/controllers/webauthn_sessions_controller.rb
+++ b/lib/generators/webauthn_authentication/templates/app/controllers/webauthn_sessions_controller.rb
@@ -1,4 +1,4 @@
-class SessionsController < ApplicationController
+class WebauthnSessionsController < ApplicationController
   allow_unauthenticated_access only: %i[new get_options create]
 
   def new

--- a/lib/generators/webauthn_authentication/webauthn_authentication_generator.rb
+++ b/lib/generators/webauthn_authentication/webauthn_authentication_generator.rb
@@ -16,7 +16,7 @@ class WebauthnAuthenticationGenerator < ::Rails::Generators::Base
   def copy_controllers_and_concerns
     template "app/controllers/webauthn_credentials_controller.rb"
     template "app/controllers/registrations_controller.rb"
-    template "app/controllers/sessions_controller.rb"
+    template "app/controllers/webauthn_sessions_controller.rb"
   end
 
   hook_for :template_engine do |template_engine|
@@ -69,7 +69,7 @@ class WebauthnAuthenticationGenerator < ::Rails::Generators::Base
           post :create_options, on: :collection
         end
 
-        resource :session, only: [ :new, :create, :destroy ] do
+        resource :webauthn_session, only: [ :new, :create, :destroy ] do
           post :get_options, on: :collection
         end
 
@@ -112,7 +112,7 @@ class WebauthnAuthenticationGenerator < ::Rails::Generators::Base
         validates :username, presence: true, uniqueness: true
 
         has_many :webauthn_credentials, dependent: :destroy
-        has_many :sessions, dependent: :destroy
+        has_many :webauthn_sessions, dependent: :destroy
 
         after_initialize do
           self.webauthn_id ||= WebAuthn.generate_user_id

--- a/test/dummy/app/controllers/webauthn_sessions_controller.rb
+++ b/test/dummy/app/controllers/webauthn_sessions_controller.rb
@@ -1,4 +1,4 @@
-class SessionsController < ApplicationController
+class WebauthnSessionsController < ApplicationController
   allow_unauthenticated_access only: %i[new get_options create]
 
   def new

--- a/test/dummy/app/views/webauthn_sessions/new.html.erb
+++ b/test/dummy/app/views/webauthn_sessions/new.html.erb
@@ -2,12 +2,12 @@
 
 <%= form_with(
   scope: :session,
-  url: session_path,
+  url: webauthn_session_path,
   id: "new-session",
   data: {
     controller: "webauthn-credentials",
     action: "webauthn-credentials#get:prevent",
-    "webauthn-credentials-options-url-value": get_options_session_path,
+    "webauthn-credentials-options-url-value": get_options_webauthn_session_path,
   }) do |form| %>
 
   <div class="field">

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     post :create_options, on: :collection
   end
 
-  resource :session, only: [ :new, :create, :destroy ] do
+  resource :webauthn_session, only: [ :new, :create, :destroy ] do
     post :get_options, on: :collection
   end
 

--- a/test/dummy/test/controllers/webauthn_sessions_controller_test.rb
+++ b/test/dummy/test/controllers/webauthn_sessions_controller_test.rb
@@ -1,23 +1,23 @@
 require "test_helper"
 
-class SessionsControllerTest < ActionDispatch::IntegrationTest
+class WebauthnSessionsControllerTest < ActionDispatch::IntegrationTest
   test "should initiate registration successfully" do
     User.create!(username: "alice")
 
-    post get_options_session_url, params: { session: { username: "alice" } }
+    post get_options_webauthn_session_url, params: { session: { username: "alice" } }
 
     assert_response :success
   end
 
   test "should return error if creating session with inexisting username" do
-    post get_options_session_url, params: { session: { username: "alice" } }
+    post get_options_webauthn_session_url, params: { session: { username: "alice" } }
 
     assert_response :unprocessable_entity
     assert_equal [ "Username doesn't exist" ], JSON.parse(response.body)["errors"]
   end
 
   test "should return error if creating session with blank username" do
-    post get_options_session_url, params: { session: { username: "" } }
+    post get_options_webauthn_session_url, params: { session: { username: "" } }
 
     assert_response :unprocessable_entity
     assert_equal [ "Username doesn't exist" ], JSON.parse(response.body)["errors"]

--- a/test/generators/webauthn_authentication_generator_test.rb
+++ b/test/generators/webauthn_authentication_generator_test.rb
@@ -20,7 +20,7 @@ class WebauthnAuthenticationGeneratorTest < Rails::Generators::TestCase
     run_generator_instance
 
     assert_file "app/controllers/registrations_controller.rb"
-    assert_file "app/controllers/sessions_controller.rb"
+    assert_file "app/controllers/webauthn_sessions_controller.rb"
     assert_file "app/controllers/webauthn_credentials_controller.rb"
     assert_file "app/controllers/concerns/authentication.rb"
 
@@ -28,14 +28,14 @@ class WebauthnAuthenticationGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/views/webauthn_credentials/new.html.erb"
     assert_file "app/views/registrations/new.html.erb"
-    assert_file "app/views/sessions/new.html.erb"
+    assert_file "app/views/webauthn_sessions/new.html.erb"
 
     assert_file "app/javascript/controllers/webauthn_credentials_controller.js"
 
     assert_file "config/initializers/webauthn.rb", /WebAuthn.configure/
 
     assert_file "test/controllers/registrations_controller_test.rb"
-    assert_file "test/controllers/sessions_controller_test.rb"
+    assert_file "test/controllers/webauthn_sessions_controller_test.rb"
     assert_file "test/system/add_credential_test.rb"
     assert_file "test/system/registration_test.rb"
     assert_file "test/system/sign_in_test.rb"
@@ -63,7 +63,7 @@ class WebauthnAuthenticationGeneratorTest < Rails::Generators::TestCase
     run_generator_instance
 
     assert_file "app/controllers/registrations_controller.rb"
-    assert_file "app/controllers/sessions_controller.rb"
+    assert_file "app/controllers/webauthn_sessions_controller.rb"
     assert_file "app/controllers/webauthn_credentials_controller.rb"
     assert_file "app/controllers/concerns/authentication.rb"
 
@@ -71,14 +71,14 @@ class WebauthnAuthenticationGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/views/webauthn_credentials/new.html.erb"
     assert_file "app/views/registrations/new.html.erb"
-    assert_file "app/views/sessions/new.html.erb"
+    assert_file "app/views/webauthn_sessions/new.html.erb"
 
     assert_file "app/javascript/controllers/webauthn_credentials_controller.js"
 
     assert_file "config/initializers/webauthn.rb", /WebAuthn.configure/
 
     assert_file "test/controllers/registrations_controller_test.rb"
-    assert_file "test/controllers/sessions_controller_test.rb"
+    assert_file "test/controllers/webauthn_sessions_controller_test.rb"
     assert_file "test/system/add_credential_test.rb"
     assert_file "test/system/registration_test.rb"
     assert_file "test/system/sign_in_test.rb"
@@ -105,7 +105,7 @@ class WebauthnAuthenticationGeneratorTest < Rails::Generators::TestCase
     run_generator_instance
 
     assert_file "app/controllers/registrations_controller.rb"
-    assert_file "app/controllers/sessions_controller.rb"
+    assert_file "app/controllers/webauthn_sessions_controller.rb"
     assert_file "app/controllers/webauthn_credentials_controller.rb"
     assert_file "app/controllers/concerns/authentication.rb"
 
@@ -113,7 +113,7 @@ class WebauthnAuthenticationGeneratorTest < Rails::Generators::TestCase
 
     assert_no_file "app/views/webauthn_credentials/new.html.erb"
     assert_no_file "app/views/registrations/new.html.erb"
-    assert_no_file "app/views/sessions/new.html.erb"
+    assert_no_file "app/views/webauthn_sessions/new.html.erb"
 
     assert_file "app/javascript/controllers/webauthn_credentials_controller.js"
 


### PR DESCRIPTION
### Details

- Rename `SessionsController` to `WebauthnSessionsController`, to avoid conflicts with Rails' generated `sessions` controller