### PR TITLE
Disable submit button until stimulus controller connects

### DIFF
--- a/test/dummy/app/javascript/controllers/webauthn_credentials_controller.js
+++ b/test/dummy/app/javascript/controllers/webauthn_credentials_controller.js
@@ -2,8 +2,12 @@ import { Controller } from "@hotwired/stimulus";
 import { create as createWebAuthnJSON, get as getWebAuthnJSON } from "@github/webauthn-json/browser-ponyfill";
 
 export default class extends Controller {
-  static targets = ["credentialHiddenInput"];
+  static targets = ["credentialHiddenInput", "submitButton"];
   static values = { optionsUrl: String }
+
+  connect() {
+    this.submitButtonTarget.disabled = false;
+  }
 
   async create() {
     try {

--- a/test/dummy/app/views/webauthn_credentials/new.html.erb
+++ b/test/dummy/app/views/webauthn_credentials/new.html.erb
@@ -14,5 +14,5 @@
     <%= form.text_field :nickname, required: true %>
   </div>
   <%= form.hidden_field :public_key_credential, data: { "webauthn-credentials-target": "credentialHiddenInput" } %>
-  <%= form.submit "Add Security Key" %>
+  <%= form.submit "Add Security Key", disabled: true, data: { "webauthn-credentials-target": "submitButton" } %>
 <% end %>


### PR DESCRIPTION
There is a race condition where sometimes (in system tests) the form gets submitted before the stimulus controller connects, causing the backend `create` endpoint to be called before the js logic gets executed.