### PR TITLE
Disable `Sign in with passkey` button until stimulus controller connects

### DIFF
--- a/lib/generators/erb/webauthn_authentication/webauthn_authentication_generator.rb
+++ b/lib/generators/erb/webauthn_authentication/webauthn_authentication_generator.rb
@@ -23,7 +23,7 @@ module Erb
                 "webauthn-credentials-options-url-value": get_options_webauthn_session_path,
               }) do |f| %>
                 <%= f.hidden_field :public_key_credential, data: { "webauthn-credentials-target": "credentialHiddenInput" } %>
-                <%= f.submit "Sign In with Passkey"%>
+                <%= f.submit "Sign In with Passkey", disabled: true, data: { "webauthn-credentials-target": "submitButton" } %>
             <% end %>
           ERB
         end

--- a/test/dummy/app/views/sessions/new.html.erb
+++ b/test/dummy/app/views/sessions/new.html.erb
@@ -20,5 +20,5 @@
     "webauthn-credentials-options-url-value": get_options_webauthn_session_path,
   }) do |f| %>
     <%= f.hidden_field :public_key_credential, data: { "webauthn-credentials-target": "credentialHiddenInput" } %>
-    <%= f.submit "Sign In with Passkey"%>
+    <%= f.submit "Sign In with Passkey", disabled: true, data: { "webauthn-credentials-target": "submitButton" } %>
 <% end %>


### PR DESCRIPTION
To prevent race conditions and to stop having this js error when loading the index page:
```
controller.ts:28 Error connecting controller

Error: Missing target element "submitButton" for "webauthn-credentials" controller
```