### PR TITLE
Fix `require_no_authentication`

### DIFF
--- a/lib/generators/webauthn_authentication/webauthn_authentication_generator.rb
+++ b/lib/generators/webauthn_authentication/webauthn_authentication_generator.rb
@@ -54,9 +54,7 @@ class WebauthnAuthenticationGenerator < ::Rails::Generators::Base
         <<-RUBY.strip_heredoc.indent(4)
 
           def require_no_authentication
-            if Current.user
-              redirect_to root_path
-            end
+            redirect_to root_path if find_session_by_cookie
           end
         RUBY
       end

--- a/test/dummy/app/controllers/concerns/authentication.rb
+++ b/test/dummy/app/controllers/concerns/authentication.rb
@@ -51,8 +51,6 @@ module Authentication
     end
 
     def require_no_authentication
-      if Current.user
-        redirect_to root_path
-      end
+      redirect_to root_path if find_session_by_cookie
     end
 end


### PR DESCRIPTION
### Issue:
In `SecondFactorAuthenticationsController` `require_no_authentication` is used to check that a current session doesn't exist already.
However, as [allow_unauthenticated_access](https://github.com/rails/rails/blob/5b8d38542127d877d2186a9e26024e5c081237ea/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt#L10-L12) is also being used, the [require_authentication](https://github.com/rails/rails/blob/5b8d38542127d877d2186a9e26024e5c081237ea/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt#L20-L22) method is skipped, which in turn causes [resume_session](https://github.com/rails/rails/blob/5b8d38542127d877d2186a9e26024e5c081237ea/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt#L24-L26) to be skipped, and therefore the `Current` attributes don't get set.

For this reason, when `require_no_authentication` gets  executed, `Current.user` is not defined yet (nor `Current.session`).
