### PR TITLE
Use `dig` to safely access session nested fields

### DIFF
--- a/test/dummy/app/controllers/second_factor_authentications_controller.rb
+++ b/test/dummy/app/controllers/second_factor_authentications_controller.rb
@@ -57,6 +57,6 @@ class SecondFactorAuthenticationsController < ApplicationController
   end
 
   def current_authentication_user_id
-    session[:current_authentication][:user_id] || session[:current_authentication]["user_id"]
+    session.dig(:current_authentication, :user_id) || session.dig(:current_authentication, "user_id")
   end
 end


### PR DESCRIPTION
### Issue 
During the `ensure_login_initiated` execution, as login was not initiated, `session[:current_authentication]`