### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
           - rails_edge
           - rails_8_1
           - rails_8_0
+        exclude:
+          - ruby: '3.2'
+            gemfile: rails_edge
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -31,3 +31,6 @@ gem "bcrypt", "~> 3.1.7"
 gem "webauthn"
 
 gem "appraisal", "~> 2.5"
+
+gem "minitest", "~> 6.0"
+gem "minitest-mock"

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -16,5 +16,7 @@ gem "pry-byebug", "~> 3.11"
 gem "bcrypt", "~> 3.1.7"
 gem "webauthn"
 gem "appraisal", "~> 2.5"
+gem "minitest", "~> 6.0"
+gem "minitest-mock"
 
 gemspec path: "../"

--- a/gemfiles/rails_8_1.gemfile
+++ b/gemfiles/rails_8_1.gemfile
@@ -16,5 +16,7 @@ gem "pry-byebug", "~> 3.11"
 gem "bcrypt", "~> 3.1.7"
 gem "webauthn"
 gem "appraisal", "~> 2.5"
+gem "minitest", "~> 6.0"
+gem "minitest-mock"
 
 gemspec path: "../"

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -16,5 +16,7 @@ gem "pry-byebug", "~> 3.11"
 gem "bcrypt", "~> 3.1.7"
 gem "webauthn"
 gem "appraisal", "~> 2.5"
+gem "minitest", "~> 6.0"
+gem "minitest-mock"
 
 gemspec path: "../"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "webauthn/rails"
 
 require "minitest/autorun"
+require "minitest/mock"
 require "active_record/railtie"
 
 require "pry-byebug"


### PR DESCRIPTION
[`minitest` has released its new major version `v6`](https://github.com/minitest/minitest/blob/master/History.rdoc#600--2025-12-17), which drops `minitest/mock` and extracted it into the `minitest-mock` gem.

As we weren't constraining its version, as soon as the new version was released the tests started to fail.

This PR fixes the issue by adding `minitest-mock` to our dependencies and require it in the `test_helper`.

It also avoids testing `rails_edge` against `ruby-3.2` since `rails_edge` now requires `ruby` to be `'>= 3.2'`.